### PR TITLE
Method signature and interface fixes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,4 @@
 import { ChartDesignerConfigOptions, ChartRendererConfigOptions, EventManagerConfigOptions } from './index'
-import { isSeat } from "./typeutils"
 
 // Set up a fully popuplated Chart Renderer config
 const fullChartRendererConfig: Required<ChartRendererConfigOptions> = {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { ChartDesignerConfigOptions, ChartRendererConfigOptions, EventManagerConfigOptions } from './index'
+import { isSeat } from "./typeutils"
 
 // Set up a fully popuplated Chart Renderer config
 const fullChartRendererConfig: Required<ChartRendererConfigOptions> = {
@@ -262,7 +263,7 @@ new seatsio.EventManager({
 })
 
 // Global seatsio object works as expected
-new seatsio.SeatingChart({
+const seatingChart = new seatsio.SeatingChart({
     workspaceKey: 'myWorkspaceKey',
     event: 'myEvent'
 })
@@ -275,4 +276,28 @@ new seatsio.EventManager({
 
 new seatsio.SeatingChartDesigner({
     secretKey: 'mySecretKey'
+})
+
+// Seating chart tests
+seatingChart.selectObjects(['A1', { id: 'someId', ticketType: 'aTicketType', amount: 2}])
+seatingChart.deselectObjects(['A1', { id: 'someId', ticketType: 'aTicketType', amount: 2}])
+
+seatingChart.listSelectedObjects().then(objects => {
+    objects.forEach(obj => {
+        obj.accessible
+        obj.category
+        obj.companionSeat
+        obj.deselect
+        obj.displayObjectType
+        obj.id
+        obj.label
+        obj.labels
+        obj.objectType
+        obj.pricing
+        obj.restrictedView
+        obj.select
+        obj.selectable
+        obj.selected
+        obj.selectedTicketType
+    })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1112,6 +1112,7 @@ interface Labels {
 export type PriceType = number | string
 
 export interface InteractiveObjectProps {
+    readonly id: string
     readonly label: string
     readonly labels: Labels
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1215,19 +1215,19 @@ export interface SeatingChart {
     changeConfig: (config: ConfigChange) => Promise<void>
     clearSelection: () => Promise<void>
     deselectCategories: (categoryIds: string[]) => Promise<void>
-    deselectObjects: (objects: string[] | Selection[]) => Promise<void>
+    deselectObjects: (objects: (string | Selection)[]) => Promise<void>
     destroy: () => void
     findObject: (label: string) => Promise<SelectableObjectProps>
     getReportBySelectability: () => Promise<Object>
     holdToken: string
     listCategories: () => Promise<Category[]>
-    listSelectedObjects: () => Promise<(any)[]>
+    listSelectedObjects: <T extends SelectableObjectProps>() => Promise<T[]>
     render: () => SeatingChart
     rerender: () => void
     resetView: () => Promise<void>
     selectCategories: (categoryIds: string[]) => Promise<void>
     selectedObjects: string[]
-    selectObjects: (objects: string [] | Selection[]) => Promise<void>
+    selectObjects: (objects: (string | Selection)[]) => Promise<void>
     pulse: (objects: string []) => Promise<void>
     unpulse: (objects: string []) => Promise<void>
     startNewSession: () => Promise<void>


### PR DESCRIPTION
This PR fixes a few issues in the type definitions:

1. Interface `InteractiveObjectProps` now `id: string` property added.
2. `selectObjects` and `deselectObjects` will now take `(string | Selection)[]` rather than an array of one or the other.
3. `listSelectedObjects` will now return `Promise<T extends SelectableObject>` rather than `Promise<any>`.