### PR TITLE
add support for per-object pricing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,6 +37,13 @@ const fullChartRendererConfig: Required<ChartRendererConfigOptions> = {
                     { ticketType: 'child', price: 70, label: 'Children' }
                 ]}
             ]
+        },
+        { objects: ['A-1', 'A-2'], price: 10 },
+        { objects: ['B-1'], ticketTypes: [
+                { ticketType: 'adult', price: 30, label: 'Adults' },
+                { ticketType: 'child', price: 20, label: 'Children' },
+                { ticketType: 'senior', price: 25, label: 'Senior', description: '65+ – Requires ID' }
+            ]
         }
     ],
     priceFormatter: price => '$' + price,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1092,15 +1092,27 @@ export type EventManagerMode =
     | 'select'
     | 'static'
 
-export type SimplePricing = {
+export type SimplePricingForCategory = {
     category: CategoryKey
     originalPrice?: number
     price: number
     channels?: ChannelPricing[]
 }
 
-export type MultiLevelPricing = {
-    category: number | string,
+export type SimplePricingForObjects = {
+    objects: string[]
+    originalPrice?: number
+    price: number
+    channels?: ChannelPricing[]
+}
+
+export type MultiLevelPricingForCategory = {
+    category: CategoryKey,
+    ticketTypes: TicketType[]
+}
+
+export type MultiLevelPricingForObjects = {
+    objects: string[]
     ticketTypes: TicketType[]
 }
 
@@ -1126,7 +1138,11 @@ export type TicketType = {
     description?: string
 }
 
-export type Pricing = (SimplePricing | MultiLevelPricing)[]
+export type PricingForCategory = (SimplePricingForCategory | MultiLevelPricingForCategory)
+
+export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForObjects)
+
+export type Pricing = (PricingForCategory | PricingForObjects)[]
 
 export type SelectionValidator =
     SelectionValidatorNoOrphanSeats

--- a/src/index.ts
+++ b/src/index.ts
@@ -1092,7 +1092,7 @@ export type EventManagerMode =
     | 'select'
     | 'static'
 
-export type SimplePricingForCategory = {
+export type SimplePricing = {
     category: CategoryKey
     originalPrice?: number
     price: number
@@ -1106,7 +1106,7 @@ export type SimplePricingForObjects = {
     channels?: ChannelPricing[]
 }
 
-export type MultiLevelPricingForCategory = {
+export type MultiLevelPricing = {
     category: CategoryKey,
     ticketTypes: TicketType[]
 }
@@ -1138,7 +1138,7 @@ export type TicketType = {
     description?: string
 }
 
-export type PricingForCategory = (SimplePricingForCategory | MultiLevelPricingForCategory)
+export type PricingForCategory = (SimplePricing | MultiLevelPricing)
 
 export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForObjects)
 


### PR DESCRIPTION
Notes: 
* I've renamed a few types, but I suppose that's not a breaking change, right?
* Apparently it's not possible to enforce uniqueness of the object labels across the whole pricing config, with just the typescript type system alone. That's unfortunate, but so be it. 