### PR TITLE
Add missing config option hideSectionsNotForSale

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -201,7 +201,8 @@ const fullChartRendererConfig: Required<ChartRendererConfigOptions> = {
     showRowLines: false,
     themeColors: 'someTheme',
     themePreset: 'somePreset',
-    tooltipStyle: 'someStyle'
+    tooltipStyle: 'someStyle',
+    hideSectionsNotForSale: false
 }
 
 // Set up a complete Event Manager config

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,6 +322,10 @@ export interface ChartRendererConfigOptions extends DeprecatedConfigProperties, 
      * Called when the chart needs to prompt how many places to select for each ticket type. {@link https://docs.seats.io/docs/renderer/prompts-api/onPlacesWithTicketTypesPrompt See documentation}
      */
     onPlacesWithTicketTypesPrompt?: (parameters: PlacesWithTicketTypesPromptParameters, confirmSelection: (placesPerTicketType: Dict<number> | string[]) => void) => void
+    /**
+     * For charts with sections, enabling this setting will hide sections where all bookable objects are set as not for sale. By extension, this will also hide entire floors if every object on it is set as not for sale. {@link https://docs.seats.io/docs/renderer/config-hidesectionsnotforsale/ See documentation}
+     */
+    hideSectionsNotForSale?: boolean
 }
 
 export type ExtractedEventManagerProps = Pick<ChartRendererConfigOptions,


### PR DESCRIPTION
`hideSectionsNotForSale` was missing from `ChartRendererConfigOptions`