### PR TITLE
Add type guards for bookable objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/index.d.ts"
+        "dist"
     ],
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "description": "Type definitions for Seats.io",
     "version": "5.3.0",
     "license": "MIT",
+    "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
         "dist/index.d.ts"
@@ -17,7 +18,7 @@
         "semver": "7.6.3"
     },
     "scripts": {
-        "build": "yarn clean && yarn tsc",
+        "build": "yarn clean && tsc",
         "clean": "rm -rf ./dist/",
         "test": "yarn tsc --noEmit src/index.test.ts",
         "test:watch": "tsc --watch src/index.test.ts"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "semver": "7.6.3"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "yarn clean && yarn tsc",
+        "clean": "rm -rf ./dist/",
         "test": "yarn tsc --noEmit src/index.test.ts",
         "test:watch": "tsc --watch src/index.test.ts"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1502,7 +1502,7 @@ export type ListingBySection = {
     quantity: number
 }
 
-// Type helper functions
+// Runtime type helper functions
 export function isBooth(object: SelectableObject): object is Booth {
     return object.objectType === 'Booth'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1501,3 +1501,20 @@ export type ListingBySection = {
     minPrice: number
     quantity: number
 }
+
+// Type helper functions
+export function isBooth(object: SelectableObject): object is Booth {
+    return object.objectType === 'Booth'
+}
+
+export function isSeat(object: SelectableObject): object is Seat {
+    return object.objectType === 'Seat'
+}
+
+export function isGeneralAdmission(object: SelectableObject): object is GeneralAdmissionArea {
+    return object.objectType === 'GeneralAdmissionArea'
+}
+
+export function isTable(object: SelectableObject): object is Table {
+    return object.objectType === 'Table'
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "dist",
         "declaration": true,
-        "emitDeclarationOnly": true
+        "emitDeclarationOnly": false
     },
     "include": [
         "src/index.ts"


### PR DESCRIPTION
This PR adds type guard functions for most bookable objects, which helps in type checking at runtime.

So instead of doing for instance `onObjectSelected={(o: SelectableObject) => if (o.objectType() === 'Seat') { (o as Seat).pulse()}}`,
 we can instead do:
`onObjectSelected={(o: SelectableObject) => isSeat(o) && o.pulse()}`

Simpler code and happy compiler.