### PR TITLE
Update pricing to include new object format

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -591,5 +591,6 @@ const objectPricing: Required<Pricing> = {
     priceFormatter: price => '$' + price,
     prices: [
         { category: 'A', price: 10, originalPrice: 15 }
-    ]
+    ],
+    showSectionPricingOverlay: true
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,8 @@ import {
     EventManagerManageChannelsModeConfigOptions,
     EventManagerManageObjectStatusesModeConfigOptions,
     EventManagerSelectModeConfigOptions,
-    EventManagerStaticModeConfigOptions
+    EventManagerStaticModeConfigOptions,
+    Pricing
 } from './index'
 
 // Set up a complete Chart Renderer config
@@ -580,3 +581,15 @@ seatingChart.listSelectedObjects().then(objects => {
 eventManager.listOrderChanges().forEach(orderChange => {
     console.log(orderChange.type, orderChange.object, orderChange.ticketType)
 })
+
+// Pricing tests
+const legacyPricing: Required<Pricing> = [
+    { category: 'A', price: 10, originalPrice: 15 }
+]
+
+const objectPricing: Required<Pricing> = {
+    priceFormatter: price => '$' + price,
+    prices: [
+        { category: 'A', price: 10, originalPrice: 15 }
+    ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1290,7 +1290,12 @@ export type PricingForCategory = (SimplePricing | MultiLevelPricing)
 
 export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForObjects)
 
-export type Pricing = (PricingForCategory | PricingForObjects)[]
+export type Pricing = ObjectPricing | LegacyPricing
+export type LegacyPricing = (PricingForCategory | PricingForObjects)[]
+export type ObjectPricing = {
+    priceFormatter?: (price: number) => string
+    prices: (PricingForCategory | PricingForObjects)[]
+}
 
 export type SelectionValidator =
     SelectionValidatorNoOrphanSeats

--- a/src/index.ts
+++ b/src/index.ts
@@ -1293,7 +1293,8 @@ export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForO
 type LegacyPricing = (PricingForCategory | PricingForObjects)[]
 export type Pricing = {
     priceFormatter?: (price: number) => string
-    prices: (PricingForCategory | PricingForObjects)[]
+    prices: (PricingForCategory | PricingForObjects)[],
+    showSectionPricingOverlay?: boolean
 } | LegacyPricing
 
 export type SelectionValidator =

--- a/src/index.ts
+++ b/src/index.ts
@@ -1290,12 +1290,11 @@ export type PricingForCategory = (SimplePricing | MultiLevelPricing)
 
 export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForObjects)
 
-export type Pricing = ObjectPricing | LegacyPricing
-export type LegacyPricing = (PricingForCategory | PricingForObjects)[]
-export type ObjectPricing = {
+type LegacyPricing = (PricingForCategory | PricingForObjects)[]
+export type Pricing = {
     priceFormatter?: (price: number) => string
     prices: (PricingForCategory | PricingForObjects)[]
-}
+} | LegacyPricing
 
 export type SelectionValidator =
     SelectionValidatorNoOrphanSeats


### PR DESCRIPTION
Updates types to support new pricing object format. Existing pricing is now named `LegacyPricing` for clarity and allowed alongside the new pricing object format.