### PR TITLE
Add fees to pricing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -588,6 +588,7 @@ const legacyPricing: Required<Pricing> = [
 ]
 
 const objectPricing: Required<Pricing> = {
+    allFeesIncluded: true,
     priceFormatter: price => '$' + price,
     prices: [
         { category: 'A', price: 10, originalPrice: 15 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -584,14 +584,14 @@ eventManager.listOrderChanges().forEach(orderChange => {
 
 // Pricing tests
 const legacyPricing: Required<Pricing> = [
-    { category: 'A', price: 10, originalPrice: 15 }
+    { category: 'A', price: 10, originalPrice: 15, fee: 10 }
 ]
 
 const objectPricing: Required<Pricing> = {
     allFeesIncluded: true,
     priceFormatter: price => '$' + price,
     prices: [
-        { category: 'A', price: 10, originalPrice: 15 }
+        { category: 'A', price: 10, originalPrice: 15, fee: 10 }
     ],
     showSectionPricingOverlay: true
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,6 +10,7 @@ import {
     EventManagerManageObjectStatusesModeConfigOptions,
     EventManagerSelectModeConfigOptions,
     EventManagerStaticModeConfigOptions,
+    LegacyPricing,
     Pricing
 } from './index'
 
@@ -583,15 +584,29 @@ eventManager.listOrderChanges().forEach(orderChange => {
 })
 
 // Pricing tests
-const legacyPricing: Required<Pricing> = [
-    { category: 'A', price: 10, originalPrice: 15, fee: 10 }
+const legacyPricing: Required<LegacyPricing> = [
+    { category: 'A', price: 10, originalPrice: 15 },
+    { category: 'B', ticketTypes: [
+        { ticketType: 'adult', price: 30, label: 'Adults' },
+    ]},
+    { objects: ['A-1', 'A-2'], price: 10 },
+    { objects: ['A-1', 'A-2'], ticketTypes: [
+        { ticketType: 'Adult', price: 10}
+    ]}
 ]
 
 const objectPricing: Required<Pricing> = {
     allFeesIncluded: true,
     priceFormatter: price => '$' + price,
     prices: [
-        { category: 'A', price: 10, originalPrice: 15, fee: 10 }
-    ],
+        { category: 'A', price: 10, originalPrice: 15, fee: 1 },
+        { category: 'B', ticketTypes: [
+            { ticketType: 'adult', price: 30, label: 'Adults', fee: 2 },
+        ]},
+        { objects: ['A-1', 'A-2'], price: 10, fee: 1 },
+        { objects: ['A-1', 'A-2'], ticketTypes: [
+            { ticketType: 'Adult', price: 10, fee: 1 }
+        ]
+    }],
     showSectionPricingOverlay: true
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1287,10 +1287,17 @@ export type TicketType = {
 }
 
 export type PricingForCategory = (SimplePricing | MultiLevelPricing)
-
 export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForObjects)
 
-type LegacyPricing = (PricingForCategory | PricingForObjects)[]
+// Legacy types for backwards compatibility
+type LegacySimplePricing = Omit<SimplePricing, 'fee'>
+type LegacyMultiLevelPricing = Omit<MultiLevelPricing, 'ticketTypes'> & { ticketTypes: Omit<TicketType, 'fee'>[] }
+type LegacySimplePricingForObjects = Omit<SimplePricingForObjects, 'fee'>
+type LegacyMultiLevelPricingForObjects = Omit<MultiLevelPricingForObjects, 'ticketTypes'> & { ticketTypes: Omit<TicketType, 'fee'>[] }
+type LegacyPricingForCategory = (LegacySimplePricing | LegacyMultiLevelPricing)
+type LegacyPricingForObjects = (LegacySimplePricingForObjects | LegacyMultiLevelPricingForObjects)
+export type LegacyPricing = (LegacyPricingForCategory | LegacyPricingForObjects)[]
+
 export type Pricing = {
     allFeesIncluded?: boolean
     priceFormatter?: (price: number) => string

--- a/src/index.ts
+++ b/src/index.ts
@@ -952,7 +952,7 @@ export type Category = {
     color: string
     key: CategoryKey
     label: string
-    pricing: { price: number, formattedPrice: string, fee?: Fee },
+    pricing: { price: number, formattedPrice: string, fee?: number },
     hasSelectableObjects: boolean
 }
 
@@ -1236,16 +1236,11 @@ export type EventManagerMode =
     | 'createOrder'
     | 'editOrder'
 
-export type Fee = {
-    amount: number
-    includedInPrice?: boolean
-}
-
 export type SimplePricing = {
     category: CategoryKey
     originalPrice?: number
     price: number
-    fee?: Fee
+    fee?: number
     channels?: ChannelPricing[]
 }
 
@@ -1253,7 +1248,7 @@ export type SimplePricingForObjects = {
     objects: string[]
     originalPrice?: number
     price: number
-    fee?: Fee
+    fee?: number
     channels?: ChannelPricing[]
 }
 
@@ -1273,7 +1268,7 @@ export type SimpleChannelPricing = {
     channel: string
     originalPrice?: number
     price: number
-    fee?: Fee
+    fee?: number
 }
 
 export type MultiLevelChannelPricing = {
@@ -1286,7 +1281,7 @@ export type TicketType = {
     ticketType: string
     originalPrice?: number
     price: number
-    fee?: Fee
+    fee?: number
     label?: string,
     description?: string
 }
@@ -1373,7 +1368,7 @@ interface TicketTypeJsonWithoutPrice {
 export interface TicketTypeJson {
     ticketType: string
     price: number
-    fee?: Fee
+    fee?: number
     originalPrice?: number,
     label?: string
     description?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -956,7 +956,7 @@ export type Category = {
     color: string
     key: CategoryKey
     label: string
-    pricing: { price: number, formattedPrice: string },
+    pricing: { price: number, formattedPrice: string, fee?: Fee },
     hasSelectableObjects: boolean
 }
 
@@ -1240,10 +1240,16 @@ export type EventManagerMode =
     | 'createOrder'
     | 'editOrder'
 
+export type Fee = {
+    amount: number
+    includedInPrice?: boolean
+}
+
 export type SimplePricing = {
     category: CategoryKey
     originalPrice?: number
     price: number
+    fee?: Fee
     channels?: ChannelPricing[]
 }
 
@@ -1251,6 +1257,7 @@ export type SimplePricingForObjects = {
     objects: string[]
     originalPrice?: number
     price: number
+    fee?: Fee
     channels?: ChannelPricing[]
 }
 
@@ -1270,6 +1277,7 @@ export type SimpleChannelPricing = {
     channel: string
     originalPrice?: number
     price: number
+    fee?: Fee
 }
 
 export type MultiLevelChannelPricing = {
@@ -1282,6 +1290,7 @@ export type TicketType = {
     ticketType: string
     originalPrice?: number
     price: number
+    fee?: Fee
     label?: string,
     description?: string
 }
@@ -1362,6 +1371,7 @@ interface TicketTypeJsonWithoutPrice {
 export interface TicketTypeJson {
     ticketType: string
     price: number
+    fee?: Fee
     originalPrice?: number,
     label?: string
     description?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1297,6 +1297,7 @@ export type PricingForObjects = (SimplePricingForObjects | MultiLevelPricingForO
 
 type LegacyPricing = (PricingForCategory | PricingForObjects)[]
 export type Pricing = {
+    allFeesIncluded?: boolean
     priceFormatter?: (price: number) => string
     prices: (PricingForCategory | PricingForObjects)[],
     showSectionPricingOverlay?: boolean


### PR DESCRIPTION
Adds types for `allFeesIncluded` and the `fee` property where we specify `price`. Also modifies legacy pricing types so that we won't show intellisense for `fee` (and show and error if specified).