### PR TITLE
support Polish ('pl') in designer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -571,7 +571,7 @@ export interface BaseChartDesignerConfigOptions {
     /**
      * Documentation: {@link https://docs.seats.io/docs/embedded-designer/configuration-language}
      */
-    language?: 'de' | 'en' | 'es' | 'fr' | 'pt' | 'it' | 'ar'
+    language?: 'de' | 'en' | 'es' | 'fr' | 'pt' | 'it' | 'ar' | 'pl'
     onChartCreated?: (chartKey: string) => void
     onChartPublished?: (chartKey: string) => void
     onChartUpdated?: (chartKey: string) => void


### PR DESCRIPTION
The designer accepts `pl` as of seatsio/seatsio-ui#2223, so the types need to allow it — otherwise TypeScript users get an error passing `language: 'pl'`.

Adds `'pl'` to the `language` union on `BaseChartDesignerConfigOptions`.
